### PR TITLE
Add map options

### DIFF
--- a/docs/archives.md
+++ b/docs/archives.md
@@ -61,14 +61,14 @@ export default withArchive(
 )( TodayArchive );
 ```
 
-`withArchive` components will automatically load the archive if it's not available in the store. Your component receives seven props:
+`withArchive` components will automatically load the archive if it's not available in the store. Your component receives five data props, and two action props:
 
 * `archiveId` (mixed): The (resolved) ID for this archive.
 * `posts` (`object[]`): A list of objects in the archive.
 * `loading` (`boolean`): Whether the archive is currently being loaded.
-* `onLoad` (`Function`: `() => Promise`): Loader function. Called automatically by the HOC, but you can call this again if needed.
 * `hasMore` (`boolean`): Whether there are more pages of the archive to load.
 * `loadingMore` (`boolean`): Whether the next page of the archive is being loaded.
+* `onLoad` (`Function`: `() => Promise`): Loader function. Called automatically by the HOC, but you can call this again if needed.
 * `onLoadMore` (`Function`: `( page = null ) => Promise`): Loader function. Call this to load the next page of the archive, or pass a page number to load that specific page.
 
 For convenience, you might want to make your own HOC to simplify this to just an ID:
@@ -93,6 +93,14 @@ export default withArchive(
 ```
 
 (The resolved ID will be passed to your component as `archiveId`.)
+
+
+### Advanced Options
+
+You can pass a fourth parameter called `options` to `withArchive`. This is an object with the following keys:
+
+* `mapDataToProps` (`Function`: `object => object`): Map the data props to props passed to your component. By default, this passes through all data props.
+* `mapActionsToProps` (`Function`: `object => object`): Map the action props to props to your component. By default, this passes through all action props.
 
 
 ## Pagination

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -58,6 +58,14 @@ export default id => withArchive( posts, state => state.posts, id );
 ```
 
 
+### Advanced Options
+
+You can pass a fourth parameter called `options` to `withSingle`. This is an object with the following keys:
+
+* `mapDataToProps` (`Function`: `object => object`): Map the data props to props passed to your component. By default, this passes through all data props.
+* `mapActionsToProps` (`Function`: `object => object`): Map the action props to props to your component. By default, this passes through all action props.
+
+
 ## Manually Connect
 
 If you're already connecting your component to the state, or want to manage the loading yourself, you can instead use the helper methods on the handler:

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -38,7 +38,7 @@ export default withSingle(
 )( SinglePost );
 ```
 
-`withSingle` components will automatically load the post if it's not available in the store. Your component receives five props:
+`withSingle` components will automatically load the post if it's not available in the store. Your component receives four data props, and two action props:
 
 * `postId` (mixed): The (resolved) ID for this post.
 * `post` (`object`): The post object.

--- a/src/withArchive.js
+++ b/src/withArchive.js
@@ -54,7 +54,7 @@ export default ( handler, getSubstate, id, options = {} ) => Component => {
 			_actions: {
 				onLoad:     () => dispatch( handler.fetchArchive( resolvedId ) ),
 				onLoadMore: page => dispatch( handler.fetchMore( getSubstate, resolvedId, page ) ),
-			}
+			},
 		};
 	};
 

--- a/src/withArchive.js
+++ b/src/withArchive.js
@@ -6,19 +6,26 @@ import { resolve } from './utilities';
 export default ( handler, getSubstate, id ) => Component => {
 	class WrappedComponent extends React.Component {
 		componentWillMount() {
-			if ( ! this.props.posts && ! this.props.loading ) {
-				this.props.onLoad();
+			if ( ! this.props._data.posts && ! this.props._data.loading ) {
+				this.props._actions.onLoad();
 			}
 		}
 
 		componentWillReceiveProps( nextProps ) {
-			if ( ! nextProps.posts && this.props.archiveId !== nextProps.archiveId ) {
-				nextProps.onLoad();
+			if ( ! nextProps._data.posts && this.props._data.archiveId !== nextProps._data.archiveId ) {
+				nextProps._actions.onLoad();
 			}
 		}
 
 		render() {
-			return <Component { ...this.props } />;
+			const { _data, _actions, ...props } = this.props;
+
+			const childProps = {
+				..._data,
+				..._actions,
+				...props,
+			};
+			return <Component { ...childProps } />;
 		}
 	}
 
@@ -28,19 +35,23 @@ export default ( handler, getSubstate, id ) => Component => {
 		const posts = handler.getArchive( substate, resolvedId );
 
 		return {
-			archiveId:   resolvedId,
-			posts,
-			loading:     handler.isArchiveLoading( substate, resolvedId ),
-			hasMore:     handler.hasMore( substate, resolvedId ),
-			loadingMore: handler.isLoadingMore( substate, resolvedId ),
+			_data: {
+				archiveId:   resolvedId,
+				posts,
+				loading:     handler.isArchiveLoading( substate, resolvedId ),
+				hasMore:     handler.hasMore( substate, resolvedId ),
+				loadingMore: handler.isLoadingMore( substate, resolvedId ),
+			},
 		};
 	};
 
 	const mapDispatchToProps = ( dispatch, props ) => {
 		const resolvedId = resolve( id, props );
 		return {
-			onLoad:     () => dispatch( handler.fetchArchive( resolvedId ) ),
-			onLoadMore: page => dispatch( handler.fetchMore( getSubstate, resolvedId, page ) ),
+			_actions: {
+				onLoad:     () => dispatch( handler.fetchArchive( resolvedId ) ),
+				onLoadMore: page => dispatch( handler.fetchMore( getSubstate, resolvedId, page ) ),
+			}
 		};
 	};
 

--- a/src/withArchive.js
+++ b/src/withArchive.js
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 
 import { resolve } from './utilities';
 
-export default ( handler, getSubstate, id ) => Component => {
+export default ( handler, getSubstate, id, options = {} ) => Component => {
+	const mapDataToProps = options.mapDataToProps || ( data => data );
+	const mapActionsToProps = options.mapActionsToProps || ( actions => actions );
+
 	class WrappedComponent extends React.Component {
 		componentWillMount() {
 			if ( ! this.props._data.posts && ! this.props._data.loading ) {
@@ -21,8 +24,8 @@ export default ( handler, getSubstate, id ) => Component => {
 			const { _data, _actions, ...props } = this.props;
 
 			const childProps = {
-				..._data,
-				..._actions,
+				...mapDataToProps( _data, props ),
+				...mapActionsToProps( _actions, props ),
 				...props,
 			};
 			return <Component { ...childProps } />;

--- a/src/withSingle.js
+++ b/src/withSingle.js
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 
 import { resolve } from './utilities';
 
-export default ( handler, getSubstate, mapPropsToId ) => Component => {
+export default ( handler, getSubstate, mapPropsToId, options = {} ) => Component => {
+	const mapDataToProps = options.mapDataToProps || ( data => data );
+	const mapActionsToProps = options.mapActionsToProps || ( actions => actions );
+
 	class WrappedComponent extends React.Component {
 		componentWillMount() {
 			if ( ! this.props._data.posts && ! this.props._data.loading ) {
@@ -21,8 +24,8 @@ export default ( handler, getSubstate, mapPropsToId ) => Component => {
 			const { _data, _actions, ...props } = this.props;
 
 			const childProps = {
-				..._data,
-				..._actions,
+				...mapDataToProps( _data, props ),
+				...mapActionsToProps( _actions, props ),
 				...props,
 			};
 			return <Component { ...childProps } />;


### PR DESCRIPTION
Fixes #13.

These are called in `render()` as it allows us to pass the data and actions needed for lifecycle hooks correctly.