### PR TITLE
Cache requests between subsequent calls

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -70,14 +70,14 @@ export default class Handler {
 	}
 
 	fetch( url, query, options = {} ) {
-		const fullUrl = url + '?' + qs.stringify( query );
-		const cacheKey = fullUrl + '!' + JSON.stringify( options );
+		const cacheKey = url + '?' + qs.stringify( query ) + '!' + JSON.stringify( options );
 		const cacheable = ! options.method || options.method === 'GET' || options.method === 'HEAD';
 
 		const args = {
 			...this.query,
 			...query,
 		};
+		const fullUrl = url + '?' + qs.stringify( args );
 		if ( cacheable && this.requests[ cacheKey ] ) {
 			return this.requests[ cacheKey ];
 		}

--- a/src/handler.js
+++ b/src/handler.js
@@ -83,6 +83,7 @@ export default class Handler {
 				.then( parseResponse );
 
 			this.requests[ cacheKey ].then( () => delete this.requests[ cacheKey ] );
+			this.requests[ cacheKey ].catch( () => delete this.requests[ cacheKey ] );
 		}
 		return this.requests[ cacheKey ];
 	}

--- a/src/handler.js
+++ b/src/handler.js
@@ -51,6 +51,7 @@ export default class Handler {
 		};
 
 		this.tempId = 0;
+		this.requests = {};
 	}
 
 	/**
@@ -71,8 +72,14 @@ export default class Handler {
 		};
 
 		const fullUrl = url + '?' + qs.stringify( args );
-		return fetch( fullUrl, { ...this.fetchOptions, ...options } )
-			.then( parseResponse );
+		const cacheKey = fullUrl + '!' + JSON.stringify( options );
+		if ( this.requests[ cacheKey ] ) {
+			this.requests[ cacheKey ] = fetch( fullUrl, { ...this.fetchOptions, ...options } )
+				.then( parseResponse );
+
+			this.requests[ cacheKey ].then( () => delete this.requests[ cacheKey ] );
+		}
+		return this.requests[ cacheKey ];
 	}
 
 	/**

--- a/src/handler.js
+++ b/src/handler.js
@@ -70,13 +70,14 @@ export default class Handler {
 	}
 
 	fetch( url, query, options = {} ) {
+		const fullUrl = url + '?' + qs.stringify( query );
+		const cacheKey = fullUrl + '!' + JSON.stringify( options );
+
 		const args = {
 			...this.query,
 			...query,
 		};
 
-		const fullUrl = url + '?' + qs.stringify( args );
-		const cacheKey = fullUrl + '!' + JSON.stringify( options );
 		if ( this.requests[ cacheKey ] ) {
 			this.requests[ cacheKey ] = fetch( fullUrl, { ...this.fetchOptions, ...options } )
 				.then( parseResponse );


### PR DESCRIPTION
This avoids calling out to the API multiple times in a row when not needed.

Fixes #18.