### PR TITLE
Use componentDid* lifecycle methods.

### DIFF
--- a/src/withSingle.js
+++ b/src/withSingle.js
@@ -8,15 +8,15 @@ export default ( handler, getSubstate, mapPropsToId, options = {} ) => Component
 	const mapActionsToProps = options.mapActionsToProps || ( actions => actions );
 
 	class WrappedComponent extends React.Component {
-		componentWillMount() {
+		componentDidMount() {
 			if ( ! this.props._data.posts && ! this.props._data.loading ) {
 				this.props._actions.onLoad();
 			}
 		}
 
-		componentWillReceiveProps( nextProps ) {
-			if ( ! nextProps._data.posts && this.props._data.postId !== nextProps._data.postId ) {
-				nextProps._actions.onLoad();
+		componentDidUpdate( prevProps ) {
+			if ( ! this.props._data.posts && prevProps._data.postId !== this.props._data.postId ) {
+				this.props._actions.onLoad();
 			}
 		}
 


### PR DESCRIPTION
Similar to #31, this PR replaces deprecated `componentWill*` lifecycle methods with their according `componentDid*` _counterpart_.