### PR TITLE
Don’t overwrite fetchOptions with local options

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -75,7 +75,7 @@ export default class Handler {
 		};
 
 		const fullUrl = url + '?' + qs.stringify( args );
-		return fetch( fullUrl, { ...this.fetchOptions, ...options } )
+		return fetch( fullUrl, { ...options, ...this.fetchOptions } )
 			.then( parseResponse );
 	}
 

--- a/src/handler.js
+++ b/src/handler.js
@@ -75,7 +75,7 @@ export default class Handler {
 		};
 
 		const fullUrl = url + '?' + qs.stringify( args );
-		return fetch( fullUrl, { ...options, ...this.fetchOptions } )
+		return fetch( fullUrl, { ...options, ...this.fetchOptions, } )
 			.then( parseResponse );
 	}
 


### PR DESCRIPTION
When using `createSingle()` or `updateSingle()` the header options set in the handler on initialisation are overwritten by the options passed to `this.fetch()` 

```js
const options = {
	method:  'POST',
	headers: { 'Content-Type': 'application/json' },
	body:    JSON.stringify( data ),
};
return this.fetch( this.url, { context: 'edit' }, options )
```

For this reason, it's not possible to use repress to create items that need auth by using an Authorization header (JWT for example). 

I'd suggest switching the order of the options being spread in the `fetch()` method so that the headers set on the handler take precedent.