### PR TITLE
Add manual pagination

### DIFF
--- a/docs/archives.md
+++ b/docs/archives.md
@@ -208,6 +208,7 @@ function Blog( props ) {
 						onClick={ () => props.onNewer() }
 					>Newer Posts</button>
 				) : null }
+			</div>
 		: null }
 	</div>;
 }

--- a/docs/archives.md
+++ b/docs/archives.md
@@ -163,6 +163,7 @@ This HOC passes the same props as `withArchive`, with the following differences:
 
 * `posts` (`object[]`): A list of objects on the given page of the archive.
 * `page` (`Number`): The current page being viewed.
+* `totalPages` (`Number`): Total number of pages available for the archive.
 
 The archive page to load should be passed via the `page` prop to your component. To override this behaviour, you can pass a `getPage` function in the `options` parameter to the HOC:
 

--- a/docs/archives.md
+++ b/docs/archives.md
@@ -105,16 +105,16 @@ You can pass a fourth parameter called `options` to `withArchive`. This is an ob
 
 ## Pagination
 
-Pagination support for archives is included out of the box. You can use either infinite scroll style ("more") or manual pagination.
+Pagination support for archives is included out of the box. You can use either infinite scroll style ("more-style") or manual pagination.
 
-With more pagination, your component will receive all posts Repress has loaded. When you load more posts, it will append these to the list of posts, and your component will receive this via the `posts` prop.
+With more-style pagination, your component will receive all posts Repress has loaded. When you load more posts, it will append these to the list of posts, and your component will receive this via the `posts` prop.
 
 With manual pagination, you specify which page of the archive to load, and your component will only receive posts on that page of the archive. When you load a different page, Repress will only pass the posts for that page. Repress will keep other pages in memory allowing for fast pagination back to already-loaded pages.
 
-Use more pagination when you want an infinite scroll list of posts that expands with additional items, or if you plan on loading the entire archive into memory. Use manual pagination when you want to show a subset of posts rather than the whole archive, or if the page number is externally controlled (e.g. in the URL).
+Use more-style pagination when you want an infinite scroll list of posts that expands with additional items, or if you plan on loading the entire archive into memory. Use manual pagination when you want to show a subset of posts rather than the whole archive, or if the page number is externally controlled (e.g. in the URL).
 
 
-### More Pagination
+### More-Style Pagination
 
 To load the next page in an archive, simply call the `onLoadMore` prop passed in by `withArchive`. Repress keeps track of which page you're accessing, and appends additional posts to the existing list of posts.
 

--- a/docs/archives.md
+++ b/docs/archives.md
@@ -105,7 +105,18 @@ You can pass a fourth parameter called `options` to `withArchive`. This is an ob
 
 ## Pagination
 
-Pagination support for archives is included out of the box. To load the next page in an archive, simply call the `onLoadMore` prop passed in by `withArchive`.
+Pagination support for archives is included out of the box. You can use either infinite scroll style ("more") or manual pagination.
+
+With more pagination, your component will receive all posts Repress has loaded. When you load more posts, it will append these to the list of posts, and your component will receive this via the `posts` prop.
+
+With manual pagination, you specify which page of the archive to load, and your component will only receive posts on that page of the archive. When you load a different page, Repress will only pass the posts for that page. Repress will keep other pages in memory allowing for fast pagination back to already-loaded pages.
+
+Use more pagination when you want an infinite scroll list of posts that expands with additional items, or if you plan on loading the entire archive into memory. Use manual pagination when you want to show a subset of posts rather than the whole archive, or if the page number is externally controlled (e.g. in the URL).
+
+
+### More Pagination
+
+To load the next page in an archive, simply call the `onLoadMore` prop passed in by `withArchive`. Repress keeps track of which page you're accessing, and appends additional posts to the existing list of posts.
 
 You usually only want to call `onLoadMore` if there actually is more to load, so you should check `hasMore` before calling the function. Also, you should typically only call `onLoadMore` based on user input (a button, link, scroll handler, etc); if you need more posts on load, increase the `per_page` parameter in your query instead.
 
@@ -143,6 +154,82 @@ function Blog( props ) {
 export default withArchive( posts, state => state.posts, 'blog' )( Blog );
 ```
 
+
+### Manual Pagination
+
+For manual pagination, use the `withPagedArchive` HOC instead of `withArchive`. This allows you to manually specify the page of the archive to load, and ignores Repress's internal page counter. Additionally, only the current page of items is passed to your component.
+
+This HOC passes the same props as `withArchive`, with the following differences:
+
+* `posts` (`object[]`): A list of objects on the given page of the archive.
+* `page` (`Number`): The current page being viewed.
+
+The archive page to load should be passed via the `page` prop to your component. To override this behaviour, you can pass a `getPage` function in the `options` parameter to the HOC:
+
+* `getPage` (`Function`: `object => Number`): Map passed props to the page number. By default, this is `props => props.page`.
+
+`onLoadMore` is automatically called for you when the page changes. You can use `this.props.hasMore` to determine whether to show navigation to the next page, and you can check `this.props.page > 1` to determine whether to show navigation to the previous page.
+
+For example, the following component renders a simple list of posts with navigation to browse back and forth:
+
+```js
+function Blog( props ) {
+	const { hasMore, loading, loadingMore, page, posts } = props;
+
+	if ( loading ) {
+		return <div>Loading…</div>;
+	}
+
+	if ( ! posts ) {
+		return <div>No posts</div>;
+	}
+
+	return <div>
+		<ol>
+			{ posts.map( post =>
+				<li key={ post.id }>{ post.title.rendered }</li>
+			) }
+		</ol>
+
+		{ loadingMore ?
+			<p>Loading more…</p>
+		: (
+			<div>
+				{ hasMore ? (
+					<button
+						type="button"
+						onClick={ () => props.onOlder() }
+					>Older Posts</button>
+				) : null }
+				{ page > 1 ? (
+					<button
+						type="button"
+						onClick={ () => props.onNewer() }
+					>Newer Posts</button>
+				) : null }
+		: null }
+	</div>;
+}
+const PagedBlog = withPagedArchive( posts, state => state.posts, 'blog' )( Blog );
+
+// A higher-level component controls the page.
+class App extends React.Component {
+	state = {
+		page: 1,
+	}
+
+	render() {
+		const { page } = this.state;
+		return (
+			<PagedBlog
+				page={ page }
+				onOlder={ () => this.setState( { page: page + 1 } ) }
+				onNewer={ () => this.setState( { page: page - 1 } ) }
+			/>
+		);
+	}
+}
+```
 
 ## Dynamic Archives
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -5,6 +5,7 @@
 Each handler's substate is an object with the following properties:
 
 * `archives`: An object containing a map from archive ID to list of object IDs.
+* `archivesByPage`: An object containing a map from page numbers to list of object IDs.
 * `posts`: A flat list of all posts objects.
 * `loadingArchive`: An array containing archive IDs currently being loaded.
 * `loadingPost`: An array containing object IDs currently being loaded.

--- a/src/handler.js
+++ b/src/handler.js
@@ -174,6 +174,44 @@ export default class Handler {
 	}
 
 	/**
+	 * Get archive results from the store, restricted to a specific page.
+	 *
+	 * Retrieves the posts for a given page of an archive.
+	 *
+	 * @param {object} substate Substate registered for the type.
+	 * @param {mixed} id Archive ID.
+	 * @param {Number} page Page number.
+	 * @return {Object[]|null} List of objects for given page of the archive, or null if none loaded.
+	 */
+	getArchivePage( substate, id, page ) {
+		if ( ! substate.archivesByPage || ! substate.posts ) {
+			return null;
+		}
+
+		const pages = substate.archivesByPage[ id ];
+		if ( ! pages ) {
+			return null;
+		}
+
+		const ids = pages[ Number( page ) ];
+		if ( ! ids ) {
+			return null;
+		}
+
+		const posts = [];
+		substate.posts.forEach( post => {
+			const position = ids.indexOf( post.id );
+			if ( position === null ) {
+				return null;
+			}
+
+			posts[ position ] = post;
+		} );
+
+		return posts;
+	}
+
+	/**
 	 * Are there more pages in the archive?
 	 *
 	 * Compares the currently loaded page against the total pages for

--- a/src/handler.js
+++ b/src/handler.js
@@ -212,6 +212,21 @@ export default class Handler {
 	}
 
 	/**
+	 * Get the total number of pages for an archive.
+	 *
+	 * @param {object} substate Substate registered for the type.
+	 * @param {mixed} id Archive ID.
+	 * @return {Number|null} Number of pages in the archive if known, null otherwise.
+	 */
+	getTotalPages( substate, id ) {
+		if ( ! substate.archivePages[ id ] ) {
+			return null;
+		}
+
+		return substate.archivePages[ id ].total || 1;
+	}
+
+	/**
 	 * Are there more pages in the archive?
 	 *
 	 * Compares the currently loaded page against the total pages for

--- a/src/handler.js
+++ b/src/handler.js
@@ -105,7 +105,7 @@ export default class Handler {
 	 * @return {Function} Action to dispatch.
 	 */
 	// eslint-disable-next-line no-undef
-	fetchArchive = id => ( dispatch, getState ) => {
+	fetchArchive = ( id, page = null ) => ( dispatch, getState ) => {
 		if ( ! ( id in this.archives ) ) {
 			throw new Error( `Invalid archive ID: ${ id }` );
 		}
@@ -114,12 +114,21 @@ export default class Handler {
 
 		const query = this.archives[ id ];
 		const queryArgs = isFunction( query ) ? query( getState() ) : query;
-		const page = Number( queryArgs.page || 1 );
+
+		// Override page if passed
+		const actualPage = Number( page || queryArgs.page || 1 );
+		queryArgs.page = actualPage;
 
 		this.fetch( this.url, queryArgs )
 			.then( results => {
 				const pages = results.__wpTotalPages || 1;
-				dispatch( { type: this.actions.archiveSuccess, id, results, page, pages } );
+				dispatch( {
+					type: this.actions.archiveSuccess,
+					id,
+					results,
+					page: actualPage,
+					pages,
+				} );
 				return id;
 			} )
 			.catch( error => {

--- a/src/handler.js
+++ b/src/handler.js
@@ -248,7 +248,7 @@ export default class Handler {
 
 		const state = getState();
 		const substate = getSubstate( state );
-		page = page || ( substate.archivePages[ id ].current || 1 ) + 1;
+		page = Number( page || ( substate.archivePages[ id ].current || 1 ) + 1 );
 
 		dispatch( { type: this.actions.archiveMoreStart, id, page } );
 

--- a/src/handler.js
+++ b/src/handler.js
@@ -504,7 +504,7 @@ export default class Handler {
 					archivePages: {
 						...state.archivePages,
 						[ action.id ]: {
-							current: 1,
+							current: action.page,
 							total:   action.pages,
 						},
 					},

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as handler } from './handler';
 export { parseResponse, mergePosts } from './utilities';
 export { default as withArchive } from './withArchive';
+export { default as withPagedArchive } from './withPagedArchive';
 export { default as withSingle } from './withSingle';

--- a/src/withPagedArchive.js
+++ b/src/withPagedArchive.js
@@ -16,10 +16,12 @@ export default ( handler, getSubstate, id, options = {} ) => Component => {
 		}
 
 		componentDidUpdate( prevProps ) {
-			if ( ! this.props._data.posts && prevProps._data.archiveId !== this.props._data.archiveId ) {
-				this.props._actions.onLoad();
-			} else if ( prevProps._data.page !== this.props._data.page ) {
-				this.props._actions.onLoadMore( this.props._data.page );
+			if ( ! this.props._data.posts ) {
+				if ( prevProps._data.archiveId !== this.props._data.archiveId ) {
+					this.props._actions.onLoad();
+				} else if ( prevProps._data.page !== this.props._data.page ) {
+					this.props._actions.onLoadMore( this.props._data.page );
+				}
 			}
 		}
 

--- a/src/withPagedArchive.js
+++ b/src/withPagedArchive.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { resolve } from './utilities';
+
+export default ( handler, getSubstate, id, options = {} ) => Component => {
+	const mapDataToProps = options.mapDataToProps || ( data => data );
+	const mapActionsToProps = options.mapActionsToProps || ( actions => actions );
+	const getPage = options.getPage || ( props => props.page );
+
+	class WrappedComponent extends React.Component {
+		componentDidMount() {
+			if ( ! this.props._data.posts && ! this.props._data.loading ) {
+				this.props._actions.onLoad();
+			}
+		}
+
+		componentDidUpdate( prevProps ) {
+			if ( ! this.props._data.posts && prevProps._data.archiveId !== this.props._data.archiveId ) {
+				this.props._actions.onLoad();
+			} else if ( prevProps._data.page !== this.props._data.page ) {
+				this.props._actions.onLoadMore( this.props._data.page );
+			}
+		}
+
+		render() {
+			const { _data, _actions, ...props } = this.props;
+
+			const childProps = {
+				...props,
+				...mapDataToProps( _data, props ),
+				...mapActionsToProps( _actions, props ),
+			};
+			return <Component { ...childProps } />;
+		}
+	}
+
+	const mapStateToProps = ( state, props ) => {
+		const substate = getSubstate( state );
+		const resolvedId = resolve( id, props );
+		const page = getPage( props );
+
+		return {
+			_data: {
+				archiveId:   resolvedId,
+				page,
+				posts:       handler.getArchivePage( substate, resolvedId, page ),
+				loading:     handler.isArchiveLoading( substate, resolvedId ),
+				hasMore:     handler.hasMore( substate, resolvedId ),
+				loadingMore: handler.isLoadingMore( substate, resolvedId ),
+			},
+		};
+	};
+
+	const mapDispatchToProps = ( dispatch, props ) => {
+		const resolvedId = resolve( id, props );
+		return {
+			_actions: {
+				onLoad:     () => dispatch( handler.fetchArchive( resolvedId ) ),
+				onLoadMore: page => dispatch( handler.fetchMore( getSubstate, resolvedId, page ) ),
+			},
+		};
+	};
+
+	return connect(
+		mapStateToProps,
+		mapDispatchToProps
+	)( WrappedComponent );
+}

--- a/src/withPagedArchive.js
+++ b/src/withPagedArchive.js
@@ -58,9 +58,10 @@ export default ( handler, getSubstate, id, options = {} ) => Component => {
 
 	const mapDispatchToProps = ( dispatch, props ) => {
 		const resolvedId = resolve( id, props );
+		const page = getPage( props );
 		return {
 			_actions: {
-				onLoad:     () => dispatch( handler.fetchArchive( resolvedId ) ),
+				onLoad:     () => dispatch( handler.fetchArchive( resolvedId, page ) ),
 				onLoadMore: page => dispatch( handler.fetchMore( getSubstate, resolvedId, page ) ),
 			},
 		};

--- a/src/withPagedArchive.js
+++ b/src/withPagedArchive.js
@@ -47,6 +47,7 @@ export default ( handler, getSubstate, id, options = {} ) => Component => {
 			_data: {
 				archiveId:   resolvedId,
 				page,
+				totalPages,
 				posts:       handler.getArchivePage( substate, resolvedId, page ),
 				loading:     handler.isArchiveLoading( substate, resolvedId ),
 				hasMore:     totalPages ? page < totalPages : true,

--- a/src/withPagedArchive.js
+++ b/src/withPagedArchive.js
@@ -41,6 +41,7 @@ export default ( handler, getSubstate, id, options = {} ) => Component => {
 		const substate = getSubstate( state );
 		const resolvedId = resolve( id, props );
 		const page = getPage( props );
+		const totalPages = handler.getTotalPages( substate, resolvedId );
 
 		return {
 			_data: {
@@ -48,7 +49,7 @@ export default ( handler, getSubstate, id, options = {} ) => Component => {
 				page,
 				posts:       handler.getArchivePage( substate, resolvedId, page ),
 				loading:     handler.isArchiveLoading( substate, resolvedId ),
-				hasMore:     handler.hasMore( substate, resolvedId ),
+				hasMore:     totalPages ? page < totalPages : true,
 				loadingMore: handler.isLoadingMore( substate, resolvedId ),
 			},
 		};


### PR DESCRIPTION
Fixes #17.

Adds a new HOC (`withPagedArchive`) to handle manual pagination, where the page is passed via the `page` property (customisable via an `options` param).

Adds `getPagedArchive` into the handler to facilitate retrieving specific pages. (`fetchMore` is continuing to be used for loading them in.)

To support this, the state now contains a `archivesByPage` data store. In Repress Next (#36) we should combine `archives`, `archivePages`, and `archivesByPage` into a single item in the state instead, as `archives` is now a redundant store of the combined subobjects in `archivesByPage`.