### PR TITLE
Add support for archive optimizers

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -68,7 +68,10 @@ export default class Handler {
 	 *   which receives the state and should return parameters.
 	 */
 	registerArchive( id, query, optimizer ) {
-		this.archives[ id ] = { query, optimizer };
+		this.archives[ id ] = {
+			query,
+			optimizer,
+		};
 	}
 
 	fetch( url, query, options = {} ) {


### PR DESCRIPTION
In cases where the API request can be short circuited, archive registration can specify an optimizer callback to select matching objects from the store based off the filters for the archive.

See #34