### PR TITLE
Add hooks to complement HOCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ export default withSingle(
 // Then just use <Post id={ 42 } /> !
 ```
 
+Alternatively, implement it with hooks (requires react-redux 7.1+):
+
+```js
+// Post.js
+import { useSingle } from '@humanmade/repress';
+import React from 'react';
+
+import { posts } from './types';
+
+const Post = props => {
+	const postData = useSingle( posts, state => state.posts, props.id );
+
+	return (
+		<div>
+			<h1>{ postData.post.title.rendered }</h1>
+		</div>
+	);
+}
+```
+
 
 ## About
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 The following topics aren't needed for most people, but are handy if you're working on advanced use cases.
 
 * [Actions](actions.md)
+* [Hooks vs HOCs](hooks-hocs.md)
 * [Internals](internals.md)
 * [Hydration](hydration.md)
 * [Advanced Uses](advanced.md) - Custom reducers and altering the internal state.

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -66,6 +66,50 @@ You can pass a fourth parameter called `options` to `withSingle`. This is an obj
 * `mapActionsToProps` (`Function`: `object => object`): Map the action props to props to your component. By default, this passes through all action props.
 
 
+## Hooks
+
+If you're using [React Hooks](https://reactjs.org/docs/hooks-reference.html), you can use the `useSingle` hook instead:
+
+```js
+// SinglePost.js
+import { useSingle } from '@humanmade/repress';
+import React from 'react';
+
+import { posts } from './types';
+
+export default function SinglePost( props ) {
+	const { post } = useSingle(
+		// Handler object:
+		posts,
+
+		// getSubstate() - returns the substate
+		state => state.posts,
+
+		// Post ID.
+		props.id
+	);
+
+	return (
+		<article>
+			<h1>{ props.post.title.rendered }</h1>
+			<p>Posted { props.post.date_gmt }</p>
+			<div
+				dangerouslySetInnerHTML={ { __html: props.post.content.rendered } }
+			/>
+		</article>
+	);
+}
+```
+
+The `useSingle` hook will automatically load the post if it's not available in the store. The hook returns receives four data props, and two action props:
+
+* `post` (`object`): The post object.
+* `loading` (`boolean`): Whether the post is currently being loaded.
+* `saving` (`boolean`): Whether the post is currently being updated.
+* `load` (`Function`: `(context = 'view') => Promise`): Loader function. Called automatically by the hook, but you can call this again if needed. (When calling manually, you can also pass the context to fetch.)
+* `update` (`Function`: `data => Promise`): Update the post. Takes the data to send to the backend (`id` is added automatically.)
+
+
 ## Manually Connect
 
 If you're already connecting your component to the state, or want to manage the loading yourself, you can instead use the helper methods on the handler:

--- a/docs/hooks-hocs.md
+++ b/docs/hooks-hocs.md
@@ -1,0 +1,41 @@
+# Hooks vs HOCs
+
+Repress supports both [React Hooks](https://reactjs.org/docs/hooks-overview.html) and [Higher Order Components (HOCs)](https://reactjs.org/docs/higher-order-components.html), so you can use whichever one works better for you.
+
+The available equivalent hooks and HOCs are:
+
+Hooks | HOCs
+-- | --
+`useSingle` | `withSingle`
+`useArchive` | `withArchive`
+`usePagedArchive` | `withPagedArchive`
+
+Hooks and HOCs contain equivalent functionality, and have very similar API surfaces. Generally the APIs they expose are only different in two ways (apart from inherent hooks vs HOCs differences):
+
+* HOCs take functions to map props to various inputs. Hooks expect you to do this in your own component.
+* HOCs pass props, and name functions accordingly with an `on...` prefix. Hooks return an object, and functions do not have a prefix.
+
+Each API form has its own benefits and detriments, and you should investigate which is best for your use case. Repress is agnostic as to which you should use generally.
+
+
+## Limitations of Hooks
+
+Note that Repress' APIs are bound by the same limitations as general React APIs, such as the [rules of hooks](https://reactjs.org/docs/hooks-rules.html). Notably, **you cannot call hooks conditionally**.
+
+For example, if you need to fetch a post *and* the author of the post, you cannot conditionally call it after the first piece of data has loaded:
+
+```js
+const postData = useSingle( posts, s => s.posts, id );
+if ( postData.post ) {
+	const author = useSingle( users, s => s.users, postData.post.author );
+}
+```
+
+To mitigate this, Repress allows passing a falsy value for the ID, which will shortcircuit loading until the ID becomes available. This allows your code to obey the rules of hooks:
+
+```js
+const postData = useSingle( posts, s => s.posts, id );
+const author = useSingle( users, s => s.users, postDate.post ? postData.post.author : null );
+```
+
+This may also be a sign that you should consider refactoring your components to separate behaviour.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"license": "ISC",
 	"peerDependencies": {
 		"react": ">= 15",
-		"react-redux": "4.x || 5.x",
+		"react-redux": "4.x || 5.x || 6.x || 7.x",
 		"redux": "3.x",
 		"redux-thunk": "2.x"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -10,4 +10,6 @@ export { default as withPagedArchive } from './withPagedArchive';
 export { default as withSingle } from './withSingle';
 
 // Hooks!
+export { default as useArchive } from './useArchive';
+export { default as usePagedArchive } from './usePagedArchive';
 export { default as useSingle } from './useSingle';

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@ export {
 	parseResponse,
 	mergePosts,
 } from './utilities';
+
+// HOCs!
 export { default as withArchive } from './withArchive';
 export { default as withPagedArchive } from './withPagedArchive';
 export { default as withSingle } from './withSingle';
+
+// Hooks!
+export { default as useSingle } from './useSingle';

--- a/src/internal-utilities.js
+++ b/src/internal-utilities.js
@@ -1,0 +1,8 @@
+import { useDispatch } from 'react-redux';
+
+function fallbackHook() {
+	throw new Error( 'react-redux does not support hooks. Update to react-redux 7.1+' );
+}
+
+export const supportsReduxHooks = useDispatch !== undefined;
+export const maybeHook = hook => supportsReduxHooks ? hook : fallbackHook;

--- a/src/useArchive.js
+++ b/src/useArchive.js
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { maybeHook } from './internal-utilities';
+
+function useArchive( handler, getSubstate, id ) {
+	const state = useSelector( state => {
+		const substate = getSubstate( state );
+		const posts = handler.getArchive( substate, id );
+
+		return {
+			posts,
+			loading: handler.isArchiveLoading( substate, id ),
+			hasMore: handler.hasMore( substate, id ),
+			loadingMore: handler.isLoadingMore( substate, id ),
+		};
+	} );
+	const dispatch = useDispatch();
+	const data = {
+		...state,
+		load: () => dispatch( handler.fetchArchive( id ) ),
+		loadMore: page => dispatch( handler.fetchMore( getSubstate, id, page ) ),
+	};
+
+	useEffect( () => {
+		if ( state.posts || state.loading ) {
+			return;
+		}
+
+		data.load();
+	}, [ id, state.loading, state.posts ] );
+
+	return data;
+}
+
+export default maybeHook( useArchive );

--- a/src/useArchive.js
+++ b/src/useArchive.js
@@ -6,6 +6,15 @@ import { maybeHook } from './internal-utilities';
 function useArchive( handler, getSubstate, id ) {
 	const state = useSelector( state => {
 		const substate = getSubstate( state );
+		if ( ! id ) {
+			return {
+				posts: null,
+				loading: false,
+				hasMore: false,
+				loadingMore: false,
+			};
+		}
+
 		const posts = handler.getArchive( substate, id );
 
 		return {
@@ -23,7 +32,7 @@ function useArchive( handler, getSubstate, id ) {
 	};
 
 	useEffect( () => {
-		if ( state.posts || state.loading ) {
+		if ( state.posts || state.loading || ! id ) {
 			return;
 		}
 

--- a/src/usePagedArchive.js
+++ b/src/usePagedArchive.js
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { maybeHook } from './internal-utilities';
+
+function usePagedArchive( handler, getSubstate, id, page ) {
+	const state = useSelector( state => {
+		const substate = getSubstate( state );
+		const totalPages = handler.getTotalPages( substate, id );
+
+		return {
+			page,
+			totalPages,
+			posts: handler.getArchivePage( substate, id, page ),
+			loading: handler.isArchiveLoading( substate, id ),
+			hasMore: totalPages ? page < totalPages : true,
+			loadingMore: handler.isLoadingMore( substate, id ),
+		};
+	} );
+	const dispatch = useDispatch();
+	const data = {
+		...state,
+		load: () => dispatch( handler.fetchArchive( id, page ) ),
+		loadMore: page => dispatch( handler.fetchMore( getSubstate, id, page ) ),
+	};
+
+	useEffect( () => {
+		if ( state.posts || state.loading ) {
+			return;
+		}
+
+		data.loadMore( page );
+	}, [ id, state.loading, state.posts, page ] );
+
+	return data;
+}
+
+export default maybeHook( usePagedArchive );

--- a/src/usePagedArchive.js
+++ b/src/usePagedArchive.js
@@ -6,6 +6,15 @@ import { maybeHook } from './internal-utilities';
 function usePagedArchive( handler, getSubstate, id, page ) {
 	const state = useSelector( state => {
 		const substate = getSubstate( state );
+		if ( ! id ) {
+			return {
+				posts: null,
+				loading: false,
+				hasMore: false,
+				loadingMore: false,
+			};
+		}
+
 		const totalPages = handler.getTotalPages( substate, id );
 
 		return {
@@ -25,7 +34,7 @@ function usePagedArchive( handler, getSubstate, id, page ) {
 	};
 
 	useEffect( () => {
-		if ( state.posts || state.loading ) {
+		if ( state.posts || state.loading || ! id ) {
 			return;
 		}
 

--- a/src/useSingle.js
+++ b/src/useSingle.js
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+function useSingle( handler, getSubstate, id ) {
+	const state = useSelector( state => {
+		const substate = getSubstate( state );
+
+		return {
+			post: handler.getSingle( substate, id ),
+			loading: handler.isPostLoading( substate, id ),
+			saving: handler.isPostSaving( substate, id ),
+		};
+	} );
+	const dispatch = useDispatch();
+
+	const data = {
+		...state,
+		load: ( context = 'view' ) => dispatch( handler.fetchSingle( id, context ) ),
+		update: data => dispatch( handler.updateSingle( {
+			id,
+			...data,
+		} ) ),
+	};
+
+	useEffect( () => {
+		if ( state.post || state.loading ) {
+			return;
+		}
+
+		data.onLoad();
+	}, [ id, state.loading, state.post ] );
+
+	return data;
+}
+
+export default useSingle;

--- a/src/useSingle.js
+++ b/src/useSingle.js
@@ -7,6 +7,14 @@ function useSingle( handler, getSubstate, id ) {
 	const state = useSelector( state => {
 		const substate = getSubstate( state );
 
+		if ( ! id ) {
+			return {
+				post: null,
+				loading: false,
+				saving: false,
+			};
+		}
+
 		return {
 			post: handler.getSingle( substate, id ),
 			loading: handler.isPostLoading( substate, id ),
@@ -25,7 +33,7 @@ function useSingle( handler, getSubstate, id ) {
 	};
 
 	useEffect( () => {
-		if ( state.post || state.loading ) {
+		if ( state.post || state.loading || ! id ) {
 			return;
 		}
 

--- a/src/useSingle.js
+++ b/src/useSingle.js
@@ -29,7 +29,7 @@ function useSingle( handler, getSubstate, id ) {
 			return;
 		}
 
-		data.onLoad();
+		data.load();
 	}, [ id, state.loading, state.post ] );
 
 	return data;

--- a/src/useSingle.js
+++ b/src/useSingle.js
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { maybeHook } from './internal-utilities';
+
 function useSingle( handler, getSubstate, id ) {
 	const state = useSelector( state => {
 		const substate = getSubstate( state );
@@ -33,4 +35,4 @@ function useSingle( handler, getSubstate, id ) {
 	return data;
 }
 
-export default useSingle;
+export default maybeHook( useSingle );


### PR DESCRIPTION
This PR adds `useSingle`, `useArchive`, and `usePagedArchive` which are analogous versions of their HOCs brethren.

Requires react-redux 7.1+, but will fail nicely (with a readable error) if you're not up-to-date.